### PR TITLE
Added route protection

### DIFF
--- a/backend/deviceservice/app/routes/device.py
+++ b/backend/deviceservice/app/routes/device.py
@@ -13,7 +13,7 @@ device_schema_list = DeviceSchema(many=True)
 
 
 class Device(Resource):
-    # @jwt_required
+    @jwt_required
     def get(self, uuid):
         device = DeviceModel.find_by_uuid(uuid)
 
@@ -22,7 +22,7 @@ class Device(Resource):
 
         return {"message": "No device found"}, 404
 
-    # @jwt_required
+    @jwt_required
     def put(self, uuid):
         device = DeviceModel.find_by_uuid(uuid)
 
@@ -31,7 +31,7 @@ class Device(Resource):
 
         return {"message": "No device found"}, 404
 
-    # @jwt_required
+    @jwt_required
     def delete(self, uuid):
         device = DeviceModel.find_by_uuid(uuid)
 
@@ -45,7 +45,7 @@ api.add_resource(Device, '/api/device/<uuid>')
 
 
 class DeviceList(Resource):
-    # @jwt_required
+    @jwt_required
     def get(self):
         return {"users": device_schema_list.dump(DeviceModel.find_all_devices())}
 


### PR DESCRIPTION
Hi there!

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for missing JSON Web Tokens (JWTs).

This generally comes up when a project is using `flask_jwt_extended` and has routes that aren't protected with the `@jwt_required` decorator. I noticed that you had the authentication decorators commented out, so I added the route protection back in case it was just missing.

Bento flagged a couple of other actionables within your codebase, but I wanted to keep the PR short. If you are curious, feel free to download and give Bento a try! (https://bento.dev)